### PR TITLE
Allow unknown properties in Wrapper's creative

### DIFF
--- a/src/schema/VAST3.ts
+++ b/src/schema/VAST3.ts
@@ -422,7 +422,7 @@ const wrapperCreativeSchema: Joi.ObjectSchema = Joi
       .optional()
       .description('Ad-ID for the creative (formerly ISCI) for wrapped Ads'),
   })
-  .unknown(false);
+  .unknown(true);
 
 /**
  * Common values of all ads.

--- a/test/documents/VAST3/valid/wrapper_unknown_creative_properties.expected
+++ b/test/documents/VAST3/valid/wrapper_unknown_creative_properties.expected
@@ -1,0 +1,63 @@
+{
+  "version": "3.0",
+  "ads": [
+    {
+      "adType": 2,
+      "VASTAdTagURI": "http://example.com/ad",
+      "adSystem": {
+        "name": "VAST"
+      },
+      "id": "287461",
+      "sequence": 1,
+      "error": "http://example.com/wrapper-error",
+      "impressions": [
+        {
+          "uri": "http://example.com/wrapper-impression"
+        }
+      ],
+      "creatives": [
+        {
+          "creativeType": 1,
+          "duration": "00:00:30",
+          "trackings": [
+            {
+              "event": 1,
+              "uri": "http://example.com/wrapper-creativeview"
+            },
+            {
+              "event": 2,
+              "uri": "http://example.com/wrapper-start"
+            },
+            {
+              "event": 3,
+              "uri": "http://example.com/wrapper-firstQuartile"
+            },
+            {
+              "event": 4,
+              "uri": "http://example.com/wrapper-midpoint"
+            },
+            {
+              "event": 5,
+              "uri": "http://example.com/wrapper-thirdQuartile"
+            },
+            {
+              "event": 6,
+              "uri": "http://example.com/wrapper-complete"
+            },
+            {
+              "event": 2,
+              "uri": "http://example.com/wrapper-start"
+            }
+          ],
+          "videoClicks": {
+            "clickTrackings": [
+              {
+                "uri": "http://example.com/wrapper-clicktracking"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/documents/VAST3/valid/wrapper_unknown_creative_properties.xml
+++ b/test/documents/VAST3/valid/wrapper_unknown_creative_properties.xml
@@ -1,4 +1,4 @@
-<!-- Wrapper with a duration -->
+<?xml version="1.0"?>
 <VAST version="3.0">
     <Ad id="287461" sequence="1">
         <Wrapper>
@@ -9,7 +9,7 @@
             <Creatives>
                 <Creative>
                     <Linear>
-                        <Duration>00:00:15</Duration>
+                        <Duration>00:00:30</Duration>
                         <TrackingEvents>
                             <Tracking event="creativeView"><![CDATA[http://example.com/wrapper-creativeview]]></Tracking>
                             <Tracking event="start"><![CDATA[http://example.com/wrapper-start]]></Tracking>
@@ -25,11 +25,6 @@
                     </Linear>
                 </Creative>
             </Creatives>
-            <Extensions>
-                <Extension type="Behavior">
-                    <Behavior type="thirdPartyAdServer">unknown</Behavior>
-                </Extension>
-            </Extensions>
         </Wrapper>
     </Ad>
 </VAST>


### PR DESCRIPTION
Some AdServing companies adds some unknown properties like a `<Duration>` in Wrapper's creatives, we should allow it.

Ex: https://bid.g.doubleclick.net/dbm/vast?dbm_c=AKAmf-CalaEwT6Z9wpR4lAXHnREPWpKQICq6Uy-GGPk5-xIeKTuhdZF8c8IWLyvIU1vY_HhscakW&dbm_d=AKAmf-BvBCmYIxdAKsb0cETqd6Qso3EaocBsQWWjH6Az6u9FbO3h9FH-hE89hfjt_9p3QikRffImrV25rF3N0Sb7TpSIh5UhlNHWQ4j8VagorrFs1t7T62CdYZDRZH6TvnAVmoFqdkI7rwNAFxzDOnx0qG5vknFHVHpMQZkBCY15ALj4RgkCIKVGbEjXpMHmAl9tUrLqqzbJ3CUfc95rbuDOZ1xNxN54dy2YoQklILcC7oqH_-CrFeL1vRgRi0xuN48fftdZ2AfiiYJ2RtNm_yUXkVxQLgGUtd-OVWISQzhOUFcXAKjS_66m1qIjLzvi-FdcP6QhFQSVfYGyXH5vm8XqBw1UZa8e-1_4lNYZIw99pEVukKsZjcdfIbG_IAAQNW2Go689zOPHhv3ZsRdSOPpqNawN-KGJ3GsogmGHSuiYbrYOGukkBpAse3PpsA_OFBTTNwS0AJNaWKIYZObeMTvXRsRzlNWdX-pVPcHM4wEP6EV9IMSvekxwiqSJSdePTHuUU9qUR2b2tTRVrkGT2tim4iy9baz8Z-HH03nyu5hzyM75OSoQHPKKV591PA6blLT8o5an4jYcubCDSCIkrWZwg6jEj9mt15CRRaNprcsQw2zRaB-GWYDVkIn3xCzHQCamzQFNTFl_aqYTsv79qHHKhe3vVIhVeaVkKFB32absM1Hl9pCaU_b39Af9DnnefsswfC9VssGZn3uIvvNpeUQqS61kf8Ndu1f1rn22chBFrpSqWuutilQf0gRgiVQz-yF9My2jRP_zLeCWfA4GVNIkX2Cv_bBnNXMjds5z8xaXaAqkd7bNnUruDA2be4WxR7nNYyE5Uz7om5YDLU6oxJ_8n2n4DvEORmV9sBQtVRhB9C4cc2Iqf2PZDMsV5FAfvZxKMZ5V-35oAdxJ2Yu0-wjRa4glqvvnrvJSLTRvi8oU6-r3ViUCboCxc2wODicUZA0T_CO3DuO2rIhsOv8c9leDJ1z9m7LqVYYPmtRidC1082yzC5GyxmSxc6s0JtR8OGJ0oQpW9wK1aOky14HmELp9iFGQ78SU5kZIRpaIDodoo6--MEddC8U032crulIYIwC3g6eCfeSPOAjud9o20iqPlwCzadBHPI7Gi1-XfcYs-o6KuKa4NoOn6BO_Yift5kz5RxWS_5eioG_ydXMGqfRqPD-GglkETJFxUc-6BAn-sjEWI3VCYyj0e4OcB4smQB3DemllaJXiMWhQ0isaESoUp5JyLwDpMkA1QDC9cHRqTXfmvTnubFzcR086PAetGL0c2FVAaoeWKTZ8ypfGfENjzz1KW5OWMLtptn3SozWfC9V_YaOqD8ujD0P35CfQwC1grTSv2cJOb5yEooDBuo9RJYxJ9GAWz4Mg-KRNWdlOMVwW3ukyBlrJYxVtjsznhlfd_G6o_2nm7-_uzmJXyvi4jFc9-tXlvw&pr=42:${AUCTION_PRICE}